### PR TITLE
add --no-debug on build

### DIFF
--- a/install.cr
+++ b/install.cr
@@ -37,7 +37,7 @@ File.write "./dev/sentry_cli.cr", sentry_cli_code
 
 # compile sentry files
 puts "🤖  Compiling sentry using --release flag..."
-build_args = ["build", "--release", "./dev/sentry_cli.cr", "-o", "./sentry"]
+build_args = ["build", "--release", "--no-debug", "./dev/sentry_cli.cr", "-o", "./sentry"]
 system "crystal", build_args
 
 puts "🤖  Sentry installed!"


### PR DESCRIPTION
```
$ curl -fsSLo- https://raw.githubusercontent.com/samueleaton/sentry/master/install.cr | crystal eval
🤖  Fetching sentry files... success
🤖  Compiling sentry using --release flag...
crystal: /var/cache/omnibus/src/llvm/llvm-3.8.1.src/lib/CodeGen/LexicalScopes.cpp:160: llvm::LexicalScope* llvm::LexicalScopes::getOrCreateRegularScope(const llvm::DILocalScope*): Assertion `cast<DISubprogram>(Scope)->describes(MF->getFunction())' failed.
Aborted (core dumped)
🤖  Sentry installed!

To execute sentry, do:
  ./sentry

To see options:
  ./sentry --help
$ ./sentry
bash: ./sentry: No such file or directory
```

*or maybe `--no-debug` just for temporary usage (until that bug fixed)