### PR TITLE
Closes #20. Add `Sentry::Config` for managing configuration, and check `.sentry.yml` on startup

### DIFF
--- a/.sentry.example.yml
+++ b/.sentry.example.yml
@@ -1,0 +1,34 @@
+# This file is used to override the default Sentry configuration without
+# having to specify the options on the command line.
+#
+# All configuration options in this file are optional, and will fall back
+# to the default values that Sentry determines based on your `shard.yml`.
+#
+# Options passed through the command line will override these settings.
+
+# The process name displayed in log output. By default, this is pulled
+# automatically from shard.yml
+name: my-program-name
+
+# Set this to `true` to show configuration information when starting Sentry.
+info: true
+
+# The command used to compile the application. Setting this option to `nil` or
+# an empty string will act like specifying `--no-build` on the command line.
+build: crystal build ./src/sentry_cli.cr -o ./my-program-name
+
+# Any additional arguments to pass to the build command. Build args may only
+# be given if the build command is a single argument.
+build_args:
+
+# The command used to run the compiled application.
+run: ./my-program-name
+
+# Any additional arguments to pass to the run command. Run args may only be
+# given if the run command is a single argument.
+run_args:
+
+# The list of patterns of files for sentry to watch.
+watch:
+  - ./src/**/*.cr
+  - ./src/**/*.ecr

--- a/.sentry.example.yml
+++ b/.sentry.example.yml
@@ -6,9 +6,9 @@
 #
 # Options passed through the command line will override these settings.
 
-# The process name displayed in log output. By default, this is pulled
-# automatically from shard.yml
-name: my-program-name
+# The name of your application when displayed in log output. By default, this
+# is the app name specified in `shard.yml`.
+display_name: my-program-name
 
 # Set this to `true` to show configuration information when starting Sentry.
 info: true

--- a/src/sentry.cr
+++ b/src/sentry.cr
@@ -12,6 +12,7 @@ module Sentry
       display_name: {
         type:    String?,
         getter:  false,
+        setter:  false,
         default: nil,
       },
       info: {
@@ -44,9 +45,12 @@ module Sentry
       }
     )
 
+    property sets_display_name : Bool = false
+
     # Initializing an empty configuration provides no default values.
     def initialize
       @display_name = nil
+      @sets_display_name = false
       @info = false
       @build = nil
       @build_args = ""
@@ -59,8 +63,17 @@ module Sentry
       @display_name ||= self.class.shard_name
     end
 
+    def display_name=(new_display_name : String)
+      @sets_display_name = true
+      @display_name = new_display_name
+    end
+
     def display_name!
       display_name.not_nil!
+    end
+
+    def sets_display_name?
+      @sets_display_name
     end
 
     def build
@@ -92,7 +105,7 @@ module Sentry
     end
 
     def merge!(other : self)
-      self.display_name = other.display_name if other.display_name
+      self.display_name = other.display_name! if other.sets_display_name?
       self.info = other.info if other.info
       self.build = other.build if other.build
       self.build_args = other.build_args.join(" ") unless other.build_args.empty?

--- a/src/sentry.cr
+++ b/src/sentry.cr
@@ -10,39 +10,50 @@ module Sentry
 
     YAML.mapping(
       name: {
-        type: String?,
-        getter: false,
-        default: nil
+        type:    String?,
+        getter:  false,
+        default: nil,
       },
       info: {
-        type: Bool,
-        default: false
+        type:    Bool,
+        default: false,
       },
       build: {
-        type: String?,
-        getter: false,
-        default: nil
+        type:    String?,
+        getter:  false,
+        default: nil,
       },
       build_args: {
-        type: String,
-        getter: false,
-        default: ""
+        type:    String,
+        getter:  false,
+        default: "",
       },
       run: {
-        type: String?,
-        getter: false,
-        default: nil
+        type:    String?,
+        getter:  false,
+        default: nil,
       },
       run_args: {
-        type: String,
-        getter: false,
-        default: ""
+        type:    String,
+        getter:  false,
+        default: "",
       },
       watch: {
-        type: Array(String),
-        default: ["./src/**/*.cr", "./src/**/*.ecr"]
+        type:    Array(String),
+        default: ["./src/**/*.cr", "./src/**/*.ecr"],
       }
     )
+
+    # Initializing an empty configuration provides no default values.
+    def initialize
+      @name = nil
+      @info = false
+      @build = nil
+      @build_args = ""
+      @run = nil
+      @run_args = ""
+      @watch = [] of String
+    end
 
     def name
       @name ||= self.class.process_name
@@ -64,7 +75,6 @@ module Sentry
       @run_args.strip.split(" ").reject(&.empty?)
     end
 
-
     setter should_build : Bool = true
 
     def should_build?
@@ -77,19 +87,26 @@ module Sentry
       end
     end
 
+    def merge!(other : self)
+      self.name = other.name if other.name
+      self.info = other.info if other.info
+      self.build = other.build if other.build
+      self.build_args = other.build_args.join(" ") unless other.build_args.empty?
+      self.run = other.run if other.run
+      self.run_args = other.run_args.join(" ") unless other.run_args.empty?
+      self.watch = other.watch unless other.watch.empty?
+    end
 
     def to_s(io : IO)
       io << <<-CONFIG
-
-          Sentry configuration:
-              process_name: #{name}
-              info:         #{info}
-              build:        #{build}
-              build_args:   #{build_args}
-              run:          #{run}
-              run_args:     #{run_args}
-              watch:        #{watch}
-
+      🤖  Sentry configuration:
+            process_name: #{name}
+            info:         #{info}
+            build:        #{build}
+            build_args:   #{build_args}
+            run:          #{run}
+            run_args:     #{run_args}
+            watch:        #{watch}
       CONFIG
     end
   end

--- a/src/sentry.cr
+++ b/src/sentry.cr
@@ -45,7 +45,9 @@ module Sentry
       }
     )
 
-    property sets_display_name : Bool = false
+    property? sets_display_name : Bool = false
+    property? sets_build_command : Bool = false
+    property? sets_run_command : Bool = false
 
     # Initializing an empty configuration provides no default values.
     def initialize
@@ -72,12 +74,13 @@ module Sentry
       display_name.not_nil!
     end
 
-    def sets_display_name?
-      @sets_display_name
-    end
-
     def build
       @build ||= "crystal build ./src/#{self.class.shard_name}.cr"
+    end
+
+    def build=(new_command : String)
+      @sets_build_command = true
+      @build = new_command
     end
 
     def build_args
@@ -86,6 +89,11 @@ module Sentry
 
     def run
       @run ||= "./#{self.class.shard_name}"
+    end
+
+    def run=(new_command : String)
+      @sets_run_command = true
+      @run = new_command
     end
 
     def run_args
@@ -107,9 +115,9 @@ module Sentry
     def merge!(other : self)
       self.display_name = other.display_name! if other.sets_display_name?
       self.info = other.info if other.info
-      self.build = other.build if other.build
+      self.build = other.build if other.sets_build_command?
       self.build_args = other.build_args.join(" ") unless other.build_args.empty?
-      self.run = other.run if other.run
+      self.run = other.run if other.sets_run_command?
       self.run_args = other.run_args.join(" ") unless other.run_args.empty?
       self.watch = other.watch unless other.watch.empty?
     end

--- a/src/sentry_cli.cr
+++ b/src/sentry_cli.cr
@@ -4,7 +4,7 @@ require "./sentry"
 begin
   shard_yml = YAML.parse File.read("shard.yml")
   name = shard_yml["name"]?
-  Sentry::Config.process_name = name.try(&.as_s)
+  Sentry::Config.shard_name = name.as_s if name
 rescue e
 end
 
@@ -16,7 +16,7 @@ OptionParser.parse! do |parser|
   parser.on(
     "-n NAME",
     "--name=NAME",
-    "Sets the name of the app process (default name: #{Sentry::Config.process_name})") { |name| cli_config.name = name }
+    "Sets the display name of the app process (default name: #{Sentry::Config.shard_name})") { |name| cli_config.display_name = name }
   parser.on(
     "-b COMMAND",
     "--build=COMMAND",
@@ -73,9 +73,9 @@ if config.info
   puts config
 end
 
-if config.name
+if Sentry::Config.shard_name
   process_runner = Sentry::ProcessRunner.new(
-    process_name: config.name,
+    display_name: config.display_name!,
     build_command: config.build,
     run_command: config.run,
     build_args: config.build_args,


### PR DESCRIPTION
This PR introduces `Sentry::Config` as a single object to manage the configuration of a `sentry` instance. The CLI also now checks for a `.sentry.yml` file in the project directory to load configurations automatically. These configurations can still be overridden by specifying options the command line, though this is now entirely optional, as all options are supported from the YAML file.

An example and explanation of the `.sentry.yml` format can be found in `.sentry.example.yml`.