### PR TITLE
Ignore files

### DIFF
--- a/.sentry.example.yml
+++ b/.sentry.example.yml
@@ -32,3 +32,8 @@ run_args:
 watch:
   - ./src/**/*.cr
   - ./src/**/*.ecr
+
+# The list of patterns of files to ignore from the watched file paths.
+ignore:
+  - /\.swp$/
+  - /^\.#/

--- a/CRYSTAL_API.md
+++ b/CRYSTAL_API.md
@@ -60,6 +60,7 @@ process_runner = Sentry::ProcessRunner.new(
   build_args: [], # Array of String
   run_args: [], # Array of String
   should_build: true, # Bool
-  files: [] # Array of String
+  files: [], # Array of String
+  ignore: [] # Array of String
 )
 ```

--- a/src/sentry_cli.cr
+++ b/src/sentry_cli.cr
@@ -82,7 +82,7 @@ if Sentry::Config.shard_name
     run_args: config.run_args,
     should_build: config.should_build?,
     files: config.watch,
-    ignore_regexes: config.ignore
+    ignore: config.ignore
   )
 
   process_runner.run

--- a/src/sentry_cli.cr
+++ b/src/sentry_cli.cr
@@ -81,7 +81,8 @@ if Sentry::Config.shard_name
     build_args: config.build_args,
     run_args: config.run_args,
     should_build: config.should_build?,
-    files: config.watch
+    files: config.watch,
+    ignore_regexes: config.ignore
   )
 
   process_runner.run


### PR DESCRIPTION
Some editors produce temporary dotfiles for which it may not be desirable to watch.  For example, Vim has [swap files](http://vimdoc.sourceforge.net/htmldoc/recover.html#swap-file) and Emacs has [file locks](http://www.gnu.org/software/emacs/manual/html_node/elisp/File-Locks.html).  Some of these files may even cause problems for Sentry.  For instance an Emacs file lock is symbolic link which causes Sentry to crash with: 
`Unable to get stat for './src/.#my_file.cr': No such file or directory (Errno)` when attempting to `get_timestamp` (happened to me when doing Amber's [Quick Start Guide](https://amberframework.org/guides/getting-started/README.md#getting-started)).  This PR address address both issues:

- Check if `File.exists?`.  Skip the scan if it does not. 
- Leverage the `.sentry.yml` to include an `ingore` key that can contain a list of patterns for files to ignore from the watched file paths. 