### PR TITLE
catches file error from underlining lib

### DIFF
--- a/src/sentry.cr
+++ b/src/sentry.cr
@@ -263,13 +263,10 @@ module Sentry
             file_changed = true if (app_process && !app_process.terminated?)
           end
         end
-      rescue ex
+      rescue ex : File::Error
         # The underlining lib for reading directories will fail very rarely, crashing Sentry
         # This catches that error and allows Sentry to carry on normally
-        # https://github.com/crystal-lang/crystal/blob/59788834554399f7fe838487a83eb466e55c6408/src/errno.cr#L37
-        unless ex.message == "readdir: Input/output error"
-          raise ex
-        end
+        # https://github.com/crystal-lang/crystal/blob/677422167cbcce0aeea49531896dbdcadd2762db/src/crystal/system/unix/dir.cr#L19
       end
 
       start_app() if (file_changed || app_process.nil?)


### PR DESCRIPTION
The fix by this PR (https://github.com/samueleaton/sentry/pull/50) stopped catching the error:

![Screen Shot 2020-04-29 at 1 26 45 PM](https://user-images.githubusercontent.com/9119269/80643881-a8dd9500-8a1d-11ea-8692-26ea0c13166c.png)

I'm gonna implement the way that was proposed in this PR (https://github.com/samueleaton/sentry/pull/52)