### PR TITLE
adds src entry path and infers from shard.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,16 +11,19 @@ Build/Runs your crystal application, watches files, and rebuilds/reruns app on f
 ## Installation
 
 To install in your project, from the root directory of your project, run:
+
 ```bash
 curl -fsSLo- https://raw.githubusercontent.com/samueleaton/sentry/master/install.cr | crystal eval
 ```
 
 If using Crystal version `0.24.2` try the following:
+
 ```bash
 curl -fsSLo- https://raw.githubusercontent.com/samueleaton/sentry/crystal-v0.24.2/install.cr | crystal eval
 ```
 
 If using Crystal version `0.23.1` or lower try the following:
+
 ```bash
 curl -fsSLo- https://raw.githubusercontent.com/samueleaton/sentry/crystal-v0.23.1/install.cr | crystal eval
 ```
@@ -50,12 +53,14 @@ Assuming `sentry.cr` was correctly placed in `[your project name]/dev/sentry.cr`
 ```
 
 Example
+
 ```bash
 $ ./sentry -h
 
 Usage: ./sentry [options]
      -n NAME, --name=NAME             Sets the display name of the app process (default name: <your_app_here>)
-     -b COMMAND, --build=COMMAND      Overrides the default build command
+     --src=PATH                       Sets the entry path for the main crystal file (default is inferred from shards.yaml)
+     -b COMMAND, --build=COMMAND      Overrides the default build command (will override --src flag)
      --build-args=ARGS                Specifies arguments for the build command
      --no-build                       Skips the build step
      -r COMMAND, --run=COMMAND        Overrides the default run command
@@ -103,6 +108,7 @@ This shows the values for the build command, run command, and watched files.
 ```
 
 Example
+
 ```
 $ ./sentry -i
 
@@ -148,6 +154,7 @@ See the `YAML.mapping` definition in the `Config` class in [the `/src/sentry.cr`
 Sentry output is colorized by default. To remove colorization, pass the `--no-color` argument.
 
 Example
+
 ```bash
 ./sentry --no-color
 ```
@@ -157,6 +164,7 @@ Example
 See [CRYSTAL_API.md](./CRYSTAL_API.md)
 
 ## Why?
+
 (1) It is tiring to have to stop and restart an app on every change.
 
 (2) Docker!

--- a/src/sentry.cr
+++ b/src/sentry.cr
@@ -24,9 +24,9 @@ module Sentry
 
     property? colorize : Bool = true
 
-    property? install_shards : Bool = false
+    property src_path : String = "./src/#{Sentry::Config.shard_name}.cr"
 
-    property? colorize : Bool = false
+    property? install_shards : Bool = false
 
     setter build_args : String = ""
 
@@ -41,6 +41,7 @@ module Sentry
       @display_name = nil
       @sets_display_name = false
       @info = false
+      @src_path = "./src/#{Sentry::Config.shard_name}.cr"
       @build = nil
       @build_args = ""
       @run = nil
@@ -68,7 +69,7 @@ module Sentry
     @build : String?
 
     def build
-      @build ||= "crystal build ./src/#{self.class.shard_name}.cr"
+      @build ||= "crystal build #{self.src_path}"
     end
 
     def build=(new_command : String)
@@ -118,6 +119,7 @@ module Sentry
       self.watch = other.watch unless other.watch.empty?
       self.install_shards = other.install_shards?
       self.colorize = other.colorize?
+      self.src_path = other.src_path
     end
 
     def to_s(io : IO)
@@ -129,6 +131,7 @@ module Sentry
             info:           #{info}
             build:          #{build}
             build_args:     #{build_args}
+            src_path:       #{src_path}
             run:            #{run}
             run_args:       #{run_args}
             watch:          #{watch}

--- a/src/sentry_cli.cr
+++ b/src/sentry_cli.cr
@@ -37,7 +37,7 @@ OptionParser.parse do |parser|
   parser.on(
     "-b COMMAND",
     "--build=COMMAND",
-    "Overrides the default build command") { |command| cli_config.build = command }
+    "Overrides the default build command (will override --src flag)") { |command| cli_config.build = command }
   parser.on(
     "--build-args=ARGS",
     "Specifies arguments for the build command") { |args| cli_config.build_args = args }

--- a/src/sentry_cli.cr
+++ b/src/sentry_cli.cr
@@ -15,9 +15,11 @@ cli_config_file_name = ".sentry.yml"
 # Set the default entry src path from shard.yml
 if shard_yml && (targets = shard_yml["targets"]?)
   if targets
+    # use targets[<shard_name>]["main"] if exists
     if name && (main_path = targets.dig?(name, "main"))
       cli_config.src_path = main_path.as_s
     elsif ((raw = targets.raw) && raw.is_a?(Hash))
+      # otherwise, use the first key you find targets[<first_key>]["main"]
       if (first_key = raw.keys[0]?) && (main_path = targets.dig?(first_key, "main"))
         cli_config.src_path = main_path.as_s
       end

--- a/src/sentry_cli.cr
+++ b/src/sentry_cli.cr
@@ -104,8 +104,6 @@ if config.info
   end
 end
 
-puts "config: #{config}"
-
 if Sentry::Config.shard_name
   process_runner = Sentry::ProcessRunner.new(
     display_name: config.display_name!,


### PR DESCRIPTION
notice in the following example how the entry path has `/server/` in the directory structure. Before, Sentry would fail because it just defaulted to `src/my_app.cr`.

This change will be more flexible and will automatically pull in the src path from the `targets` object in the `shard.yml` file.

```yaml
name: my_app
version: 0.1.0

authors:
  - Sam Eaton <sam@eaton.party>

targets:
  my_app:
    main: src/server/my_app.cr

crystal: 1.2.2

```